### PR TITLE
fix: typo in introduction.md

### DIFF
--- a/docs/guias/programacion/introduction.md
+++ b/docs/guias/programacion/introduction.md
@@ -83,7 +83,7 @@ Por otro lado, podemos extender un poco este comando para personalizar el ejecut
 
 #### Compilando en Windows
 
-Para compilar en windows utilizaremos el siguiente comando
+Para compilar en Windows utilizaremos el siguiente comando
 
 ```bash
 $ go build -o compilado-hello-world.exe hello-world.go
@@ -91,7 +91,7 @@ $ go build -o compilado-hello-world.exe hello-world.go
 
 #### Compilando en MacOs/Linux
 
-Para compilar en windows utilizaremos el siguiente comando
+Para compilar en MacOs/Linux utilizaremos el siguiente comando
 
 ```bash
 $ go build -o compilado-hello-world hello-world.go


### PR DESCRIPTION
Se ajusta un error en la documentación que indica como compilar programas de GO en distintos sistemas operativos